### PR TITLE
docs: polish first-time install setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,26 @@ If you want to contribute code, start by opening an issue or picking an existing
 - Node.js
 - `pnpm`
 - Rust toolchain
-- Android Platform Tools (`adb`) in `PATH`
+- Android Platform Tools with `adb` in `PATH`
+- Fire TV with ADB debugging enabled for manual device testing
+- Spotify Developer app credentials for Spotify auth flows
+
+After installing Android Platform Tools, open a new PowerShell window and verify:
+
+```powershell
+adb version
+adb devices
+```
+
+If `adb` is not found, add the Platform Tools directory to the Windows user
+`PATH` and restart the terminal. For Fire TV testing, the TV and development
+machine must be on the same network, ADB debugging must be enabled on the TV,
+and the TV may show an authorization prompt on the first connection.
+
+Spotify flows require a Spotify Developer app. Use the app's client ID, client
+secret, and the redirect URL expected by Sendo. When testing playback routing,
+select the explicit Spotify Connect target in the app instead of relying on the
+currently active Spotify device.
 
 ### Install dependencies
 
@@ -47,6 +66,10 @@ pnpm install
 cd C:\Users\akuma\repos\desk-remote\apps\tauri
 pnpm tauri dev
 ```
+
+For a first successful manual action, configure the Fire TV IP in `ADB &
+Device`, test the ADB connection, authenticate Spotify, choose the intended
+target device, then run `Start Spotify on TV`.
 
 ### Run the site
 

--- a/apps/site/app/install/page.tsx
+++ b/apps/site/app/install/page.tsx
@@ -17,9 +17,10 @@ import { getLatestRelease } from "@/lib/releases";
 
 const requirements = [
   "Windows",
-  "adb available in PATH",
-  "Fire TV with ADB debugging enabled",
-  "Spotify developer credentials if your setup needs them",
+  "adb available from a new PowerShell window",
+  "Fire TV with ADB debugging enabled and authorized",
+  "Spotify Premium plus developer app credentials",
+  "Explicit Spotify Connect target selected in Sendo",
 ];
 
 export default async function InstallPage() {
@@ -39,8 +40,9 @@ export default async function InstallPage() {
                 </h1>
                 <p className="mt-6 max-w-2xl text-base leading-8 text-slate-300 md:text-lg">
                   Download the Windows build, enable Fire TV control over ADB,
-                  connect Spotify, and keep Sendo available from the tray for
-                  repeatable media actions.
+                  connect Spotify with the correct OAuth credentials, select
+                  the intended target device, and keep Sendo available from the
+                  tray for repeatable media actions.
                 </p>
                 <div className="mt-8 flex flex-wrap gap-3">
                   <Link
@@ -100,7 +102,8 @@ export default async function InstallPage() {
                 <div className="mt-6 rounded-[18px] border border-white/10 bg-cyan-300/[0.04] p-4">
                   <p className="text-sm leading-7 text-slate-300">
                     Sendo is local-first. There is no cloud setup layer between
-                    install and device control.
+                    install and device control, so Windows, ADB, Fire TV, and
+                    Spotify setup all happen on your machine.
                   </p>
                 </div>
               </div>
@@ -147,7 +150,8 @@ export default async function InstallPage() {
               <div className="mt-5 space-y-4 text-sm leading-7 text-slate-300">
                 <p>
                   The install itself is straightforward. Most first-run failures
-                  come from missing ADB, Fire TV debugging not enabled, or
+                  come from missing ADB, Fire TV debugging not enabled or not
+                  authorized, Spotify redirect credentials not matching, or
                   selecting the wrong Spotify device.
                 </p>
                 <p>
@@ -182,14 +186,18 @@ export default async function InstallPage() {
                   <span className="mt-[2px] font-mono text-[12px] font-semibold uppercase tracking-[0.18em] text-cyan-200/80">
                     02
                   </span>
-                  <span>Enable Fire TV debugging before opening the app.</span>
+                  <span>
+                    Enable Fire TV debugging and approve the first connection
+                    prompt on the TV.
+                  </span>
                 </li>
                 <li className="flex gap-3">
                   <span className="mt-[2px] font-mono text-[12px] font-semibold uppercase tracking-[0.18em] text-cyan-200/80">
                     03
                   </span>
                   <span>
-                    Authenticate Spotify and explicitly select a target.
+                    Authenticate Spotify with the developer app credentials and
+                    explicitly select a target.
                   </span>
                 </li>
               </ol>
@@ -308,9 +316,38 @@ function TroubleshootingBody({ title }: { title: string }) {
         <li className="flex gap-3">
           <span className="text-cyan-200">-</span>
           <span>
+            Accept the debugging authorization prompt on the TV the first time
+            the Windows machine connects.
+          </span>
+        </li>
+        <li className="flex gap-3">
+          <span className="text-cyan-200">-</span>
+          <span>
             Confirm <code className={codeClass}>adb</code> is available in{" "}
             <code className={codeClass}>PATH</code>.
           </span>
+        </li>
+      </ul>
+    );
+  }
+
+  if (title === "Spotify auth fails") {
+    return (
+      <ul className="mt-3 space-y-2 text-sm leading-7 text-slate-300">
+        <li className="flex gap-3">
+          <span className="text-cyan-200">-</span>
+          <span>Open the Spotify Developer dashboard.</span>
+        </li>
+        <li className="flex gap-3">
+          <span className="text-cyan-200">-</span>
+          <span>
+            Confirm the client ID, client secret, and redirect URL match the
+            values entered in Sendo.
+          </span>
+        </li>
+        <li className="flex gap-3">
+          <span className="text-cyan-200">-</span>
+          <span>Run authentication again from the Spotify page.</span>
         </li>
       </ul>
     );

--- a/apps/site/content/site.ts
+++ b/apps/site/content/site.ts
@@ -34,20 +34,25 @@ export const site = {
     "Quick access actions",
   ],
   installSteps: [
-    "Install Sendo on Windows.",
-    "Enable ADB debugging on your Fire TV.",
-    "Add the Fire TV IP address in Sendo.",
-    "Connect Spotify and select a target device.",
-    "Run a first action and save it as a shortcut if you want.",
+    "Install Sendo on Windows and confirm adb works from a new PowerShell window.",
+    "Enable ADB debugging on your Fire TV and approve the first connection prompt.",
+    "Add the Fire TV IP address in Sendo, then test the ADB connection.",
+    "Connect Spotify with developer app credentials and the expected redirect URL.",
+    "Select the exact Spotify Connect target device before running an action.",
+    "Run Start Spotify on TV and save it as a shortcut if you want.",
   ],
   troubleshooting: [
     {
       title: "ADB not connected",
-      body: "Check that the TV is on the same network, ADB debugging is enabled, and `adb` is available in your PATH.",
+      body: "Check that adb is on PATH, the TV is on the same network, ADB debugging is enabled, and the TV accepted the authorization prompt.",
     },
     {
       title: "Wrong Spotify device",
       body: "Open Spotify in Sendo and pick the explicit target device instead of relying on whatever Spotify marked as current.",
+    },
+    {
+      title: "Spotify auth fails",
+      body: "Confirm the client ID, client secret, and redirect URL match the Spotify Developer app exactly.",
     },
     {
       title: "Auth expired",

--- a/readme.md
+++ b/readme.md
@@ -87,10 +87,31 @@ TypeScript UI
 - Node.js
 - `pnpm`
 - Rust toolchain
-- Android Platform Tools (`adb`) in `PATH`
+- Android Platform Tools with `adb` in `PATH`
 - Fire TV with ADB debugging enabled
 - Spotify Premium
 - Spotify Developer app credentials
+
+On Windows, install Android Platform Tools and make sure the folder that
+contains `adb.exe` is on `PATH`. A quick check from a new PowerShell window is:
+
+```powershell
+adb version
+adb devices
+```
+
+If PowerShell cannot find `adb`, restart the terminal after updating `PATH` or
+use the full path to `adb.exe` until the environment is fixed.
+
+Before first run, enable ADB debugging on the Fire TV, keep the TV and Windows
+machine on the same network, and accept the Fire TV debugging prompt the first
+time Sendo or `adb connect <fire-tv-ip>` reaches the device.
+
+For Spotify, create a Spotify Developer app, copy the client ID and client
+secret into Sendo, and use the redirect URL shown by the app. After
+authentication, select the exact Spotify Connect device you want Sendo to
+control; do not rely on Spotify's current-device guess when more than one TV,
+speaker, or browser session is available.
 
 ### Clone and install
 
@@ -135,11 +156,25 @@ cd C:\Users\akuma\repos\desk-remote\apps\tauri
 ## Main Flow
 
 1. Configure the Fire TV IP address in `ADB & Device`.
-2. Configure Spotify OAuth credentials and redirect URL in `Spotify`.
-3. Authenticate Spotify and select the exact Spotify Connect target device.
-4. Use `Start Spotify on TV` from Home, tray, or a binding.
-5. Sendo connects to the TV over ADB, wakes it if needed, launches Spotify, and transfers playback to the selected Spotify device.
-6. Control playback from the Spotify page, Remote page, Quick Access, or global hotkeys.
+2. Test the ADB connection and approve the debugging prompt on the TV if it appears.
+3. Configure Spotify OAuth credentials and redirect URL in `Spotify`.
+4. Authenticate Spotify and select the exact Spotify Connect target device.
+5. Use `Start Spotify on TV` from Home, tray, or a binding.
+6. Sendo connects to the TV over ADB, wakes it if needed, launches Spotify, and transfers playback to the selected Spotify device.
+7. Control playback from the Spotify page, Remote page, Quick Access, or global hotkeys.
+
+## First-run troubleshooting
+
+- `adb` is not found: confirm Android Platform Tools are installed and the
+  platform-tools directory is on `PATH` in a new terminal.
+- Fire TV does not connect: confirm ADB debugging is enabled, both devices are
+  on the same network, and the TV accepted the debugging authorization prompt.
+- Spotify auth fails: confirm the client ID, client secret, and redirect URL in
+  Sendo match the Spotify Developer app exactly.
+- Playback transfers to the wrong device: open the Spotify page and select the
+  intended Spotify Connect target explicitly before running the action.
+- First action still fails: check the Health page first; it separates ADB,
+  Spotify auth, target selection, and startup/tray readiness.
 
 ## Why it exists
 


### PR DESCRIPTION
## Summary
Polishes first-time setup docs across the README, contributor guide, and install page.

## Why
New users need clearer expectations for Windows adb setup, Fire TV debugging, Spotify auth, explicit target selection, and common first-run failure paths.

Closes #13

## Validation
- `git diff --check`
- `cd apps/site && pnpm install --frozen-lockfile`
- `cd apps/site && pnpm build`

## UI changes
- [ ] No UI changes
- [x] UI changed; copy-only install page update

## Notes
No behavior changes.